### PR TITLE
.travis.yml: simplify, remove Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-env:
-  - PYTHON=python2.6
-  - PYTHON=python2.7
-script: virtualenv venv -p $PYTHON && . venv/bin/activate && ./unittest.sh
+python:
+  - "2.7"
+script: ./unittest.sh


### PR DESCRIPTION
There’s no need for a virtualenv here; Travis has builtin support for multiple Python versions.  However, oneliner does not work in Python 2.6, because `ast.DictComp` is new in 2.7.  The Python 2.6 tests only appeared to pass because `python -m unittest runtests` runs no tests.