### PR TITLE
Encode numbers using repr(), not str()

### DIFF
--- a/main.py
+++ b/main.py
@@ -342,7 +342,7 @@ def code_with_after(tree, after):
     elif type(tree) is ast.NotIn:
         return ' not in '
     elif type(tree) is ast.Num:
-        return str(tree.n)
+        return repr(tree.n)
     elif type(tree) is ast.Or:
         return ' or '
     elif type(tree) is ast.Pass:

--- a/tests/num_repr.py
+++ b/tests/num_repr.py
@@ -1,0 +1,4 @@
+print repr(123)
+print repr(123.0)
+print repr(123L)
+print repr(123j)


### PR DESCRIPTION
The relevant difference is `repr(123L) == '123L'`, `str(123L) == '123'`.