### PR TITLE
Replace fake __g dict with real globals

### DIFF
--- a/tests/override_builtin.py
+++ b/tests/override_builtin.py
@@ -1,0 +1,4 @@
+False = True
+while False:
+    print False
+    del False


### PR DESCRIPTION
This fixes #38, and also makes it possible to oneline a library that is imported elsewhere.